### PR TITLE
AWS4 compatibility fixes

### DIFF
--- a/httpie_aws_auth.py
+++ b/httpie_aws_auth.py
@@ -7,7 +7,6 @@ import sys
 
 from httpie.status import ExitStatus
 from httpie.plugins import AuthPlugin
-from httpie.compat import bytes
 from awsauth import S3Auth
 
 

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     },
     install_requires=[
         'httpie>=0.9.7',
-        'requests-aws>=0.1.8'
+        'requests-aws4auth>=1.0.0'
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
- Remove obsolete httpie.compat
- fix use of obsolete aws authentication
  - Fixes: `The authorization mechanism you have provided is not supported. Please use AWS4-HMAC-SHA256.`